### PR TITLE
doc(readme): use correct name when loading the extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Install Telescope and this extension, for example with lazy.nvim:
     "pfdzm/graphite-picker",
   },
   config = function()
-    require("telescope").load_extension("graphite")
+    require("telescope").load_extension("graphite_picker")
   end
 }
 ```


### PR DESCRIPTION
Is `graphite_picker`, not `graphite`