### PR TITLE
🔭 Add initial previewer

### DIFF
--- a/lua/graphite_picker/init.lua
+++ b/lua/graphite_picker/init.lua
@@ -1,5 +1,6 @@
 local pickers = require("telescope.pickers")
 local finders = require("telescope.finders")
+local previewers = require("telescope.previewers")
 local conf = require("telescope.config").values
 local actions = require("telescope.actions")
 local action_state = require("telescope.actions.state")
@@ -18,6 +19,12 @@ local graphite_picker = function(opts)
 						display = entry,
 						ordinal = entry,
 					}
+				end,
+			}),
+
+			previewer = previewers.new_termopen_previewer({
+				get_command = function(entry, status)
+					return { "gt", "log", "--no-interactive", "--reverse" }
 				end,
 			}),
 


### PR DESCRIPTION
It simply runs `gt log` for every branch you select. I didn't find a `gt` option to restrict logging to a selected branch without running gt co. Which maybe could be done in a copy of the repo? 🤔 

An alternative could be `git log`, but that's not very clean when using graphite. It includes `graphite-base` branches and so on.

But maybe it's enough for a first version.